### PR TITLE
Added permission for creating sky islands.

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -10,3 +10,6 @@ permissions:
   skyblock.interaction:
     description: Allows players to interact with an island regardless of whether they belong to it
     default: op
+  skyblock.allowed:
+    description: Alows players to create their own island.
+    default: op


### PR DESCRIPTION
Added skyblock.allowed permission to control sky island creation, all it does is check for the permission on create command and if not found returns an error message, could be costumized to work with 