### PR TITLE
Added permission for creating sky islands.

### DIFF
--- a/src/room17/SkyBlock/command/presets/CreateCommand.php
+++ b/src/room17/SkyBlock/command/presets/CreateCommand.php
@@ -70,6 +70,10 @@ class CreateCommand extends IslandCommand {
             $session->sendTranslatedMessage(new MessageContainer("NEED_TO_BE_FREE"));
             return;
         }
+        if(!$session->getPlayer()->hasPermission("skyblock.allowed")){//if player does not have permission, don't create.
+            $session->getPlayer()->sendMessage('You are not allowed to create sky islands.');
+            return;
+        };
         $minutesSinceLastIsland = $session->getLastIslandCreationTime() !== null
             ? (microtime(true) - $session->getLastIslandCreationTime()) / 60
             : -1;


### PR DESCRIPTION
Added skyblock.allowed permission to control sky island creation, all it does is check for the permission on create command and if not found returns an error message, could be costumized to work with 